### PR TITLE
Support publishing to multiple clouds

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -24,6 +24,7 @@ linters:
   - lll
   - mnd
   - nestif
+  - nilnil
   - nlreturn
   - varnamelen
   - wsl

--- a/glci.yaml
+++ b/glci.yaml
@@ -63,6 +63,7 @@ publishing:
     - source: S3
       config: gardenlinux
     - source: S3-China
+      cloud: China
       config: gardenlinux-cn
     image_tags:
       static_tags:

--- a/internal/cloudprovider/cloudprovider.go
+++ b/internal/cloudprovider/cloudprovider.go
@@ -7,6 +7,7 @@ import (
 	"io"
 
 	"github.com/go-viper/mapstructure/v2"
+	"github.com/goccy/go-yaml"
 
 	"github.com/gardenlinux/glci/internal/gl"
 )
@@ -32,7 +33,7 @@ type PublishingTarget interface {
 	Close() error
 	ImageSuffix() string
 	Publish(ctx context.Context, cname string, manifest *gl.Manifest, sources map[string]ArtifactSource) (PublishingOutput, error)
-	Remove(ctx context.Context, cname string, manifest *gl.Manifest, sources map[string]ArtifactSource) error
+	Remove(ctx context.Context, manifest *gl.Manifest, sources map[string]ArtifactSource) (PublishingOutput, error)
 }
 
 // OCMTarget is a target onto which GLCI can publish an OCM component descriptor.
@@ -156,4 +157,20 @@ func setConfig[CONFIG any](cfg map[string]any, config *CONFIG) error {
 	}
 
 	return nil
+}
+
+func publishingOutput[PUBOUT any](manifest *gl.Manifest) (PUBOUT, error) {
+	var pubOut PUBOUT
+
+	b, err := yaml.Marshal(manifest.PublishedImageMetadata)
+	if err != nil {
+		return pubOut, fmt.Errorf("invalid published image metadata in manifest: %w", err)
+	}
+
+	err = yaml.Unmarshal(b, &pubOut)
+	if err != nil {
+		return pubOut, fmt.Errorf("invalid published image metadata in manifest: %w", err)
+	}
+
+	return pubOut, nil
 }

--- a/internal/cloudprovider/fake.go
+++ b/internal/cloudprovider/fake.go
@@ -75,8 +75,8 @@ func (p *fake) Publish(_ context.Context, _ string, _ *gl.Manifest, _ map[string
 	return p, nil
 }
 
-func (*fake) Remove(_ context.Context, _ string, _ *gl.Manifest, _ map[string]ArtifactSource) error {
-	return nil
+func (p *fake) Remove(_ context.Context, _ *gl.Manifest, _ map[string]ArtifactSource) (PublishingOutput, error) {
+	return p, nil
 }
 
 func (*fake) OCMRepository() string {

--- a/internal/glci/glci.go
+++ b/internal/glci/glci.go
@@ -204,11 +204,12 @@ func Remove(ctx context.Context, flavorsConfig FlavorsConfig, publishingConfig P
 		lctx := log.WithValues(ctx, "cname", publication.Cname, "platform", publication.Target.Type())
 
 		log.Info(lctx, "Removing image")
-		err = publication.Target.Remove(lctx, publication.Cname, publication.Manifest, sources)
+		var output cloudprovider.PublishingOutput
+		output, err = publication.Target.Remove(lctx, publication.Manifest, sources)
 		if err != nil {
 			return fmt.Errorf("cannot remove %s from %s: %w", publication.Cname, publication.Target.Type(), err)
 		}
-		publications[i].Manifest.PublishedImageMetadata = nil
+		publications[i].Manifest.PublishedImageMetadata = output
 
 		log.Info(lctx, "Updating manifest")
 		err = manifestTarget.PutManifest(lctx, fmt.Sprintf("meta/singles/%s-%s-%.8s", publication.Cname, version, commit),


### PR DESCRIPTION
**What this PR does / why we need it**:
Sometimes a given flavor needs to be published to more than one cloud of the same provider - e.g. AWS public and AWS China. For this each implementation must preserve published image metadata for clouds other than the one being worked on. This needs to happen both during publishing and removing.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Support publishing to multiple clouds
```
